### PR TITLE
Refactor session handling and rename service field

### DIFF
--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Faq.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Faq.cshtml.cs
@@ -8,25 +8,17 @@ namespace digioz.Forum.Areas.Forum.Pages
 {
     public class FaqModel : PageModel
     {
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
-        public FaqModel(IForumSessionService forumConfigService)
+        public FaqModel(IForumSessionService forumSessionService)
         {
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         public void OnGet()
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Forum.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Forum.cshtml.cs
@@ -8,25 +8,17 @@ namespace digioz.Forum.Areas.Forum.Pages
 {
     public class ForumModel : PageModel
     {
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
-        public ForumModel(IForumSessionService forumConfigService)
+        public ForumModel(IForumSessionService forumSessionService)
         {
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         public void OnGet()
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Index.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Index.cshtml.cs
@@ -10,27 +10,19 @@ namespace digioz.Forum.Areas.Forum.Pages
 {
     public class IndexModel : PageModel
     {
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
         private readonly ILogger<IndexModel> _logger;
 
         public IndexModel(ILogger<IndexModel> logger, IForumSessionService forumSessionService)
         {
             _logger = logger;
-            _forumConfigService = forumSessionService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         public void OnGet()
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
 
             var context = new DigiozForumContext();
             var users = context.AspNetUsers.ToList();

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Mcp.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Mcp.cshtml.cs
@@ -8,25 +8,17 @@ namespace digioz.Forum.Areas.Forum.Pages
 {
     public class McpModel : PageModel
     {
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
-        public McpModel(IForumSessionService forumConfigService)
+        public McpModel(IForumSessionService forumSessionService)
         {
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         public void OnGet()
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Members.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Members.cshtml.cs
@@ -8,25 +8,17 @@ namespace digioz.Forum.Areas.Forum.Pages
 {
     public class MembersModel : PageModel
     {
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
-        public MembersModel(IForumSessionService forumConfigService)
+        public MembersModel(IForumSessionService forumSessionService)
         {
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         public void OnGet()
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Online.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Online.cshtml.cs
@@ -8,25 +8,17 @@ namespace digioz.Forum.Areas.Forum.Pages
 {
     public class OnlineModel : PageModel
     {
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
-        public OnlineModel(IForumSessionService forumConfigService)
+        public OnlineModel(IForumSessionService forumSessionService)
         {
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         public void OnGet()
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Privacy.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Privacy.cshtml.cs
@@ -8,27 +8,19 @@ namespace digioz.Forum.Areas.Forum.Pages
 {
     public class PrivacyModel : PageModel
     {
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
         private readonly ILogger<PrivacyModel> _logger;
 
         public PrivacyModel(ILogger<PrivacyModel> logger, IForumSessionService forumSessionService)
         {
             _logger = logger;
-            _forumConfigService = forumSessionService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         public void OnGet()
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
         }
     }
 

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Profile.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Profile.cshtml.cs
@@ -8,25 +8,17 @@ namespace digioz.Forum.Areas.Forum.Pages
 {
     public class ProfileModel : PageModel
     {
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
-        public ProfileModel(IForumSessionService forumConfigService)
+        public ProfileModel(IForumSessionService forumSessionService)
         {
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         public void OnGet()
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Search.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Search.cshtml.cs
@@ -8,25 +8,17 @@ namespace digioz.Forum.Areas.Forum.Pages
 {
     public class SearchModel : PageModel
     {
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
-        public SearchModel(IForumSessionService forumConfigService)
+        public SearchModel(IForumSessionService forumSessionService)
         {
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         public void OnGet()
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Topic.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Topic.cshtml.cs
@@ -8,25 +8,17 @@ namespace digioz.Forum.Areas.Forum.Pages
 {
     public class TopicModel : PageModel
     {
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
-        public TopicModel(IForumSessionService forumConfigService)
+        public TopicModel(IForumSessionService forumSessionService)
         {
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         public void OnGet()
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Ucp.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Ucp.cshtml.cs
@@ -8,25 +8,17 @@ namespace digioz.Forum.Areas.Forum.Pages
 {
     public class UcpModel : PageModel
     {
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
-        public UcpModel(IForumSessionService forumConfigService)
+        public UcpModel(IForumSessionService forumSessionService)
         {
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         public void OnGet()
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/AccessDenied.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/AccessDenied.cshtml.cs
@@ -15,20 +15,11 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
     /// </summary>
     public class AccessDeniedModel : PageModel
     {
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
-        public AccessDeniedModel(IForumSessionService forumConfigService)
+        public AccessDeniedModel(IForumSessionService forumSessionService)
         {
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         /// <summary>
@@ -37,7 +28,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
         /// </summary>
         public void OnGet()
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ConfirmEmail.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ConfirmEmail.cshtml.cs
@@ -20,21 +20,12 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
     public class ConfirmEmailModel : PageModel
     {
         private readonly UserManager<IdentityUser> _userManager;
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
-        public ConfirmEmailModel(UserManager<IdentityUser> userManager, IForumSessionService forumConfigService)
+        public ConfirmEmailModel(UserManager<IdentityUser> userManager, IForumSessionService forumSessionService)
         {
             _userManager = userManager;
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         /// <summary>
@@ -45,7 +36,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
         public string StatusMessage { get; set; }
         public async Task<IActionResult> OnGetAsync(string userId, string code)
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
 
             if (userId == null || code == null)
             {

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ConfirmEmailChange.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ConfirmEmailChange.cshtml.cs
@@ -20,22 +20,13 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
     {
         private readonly UserManager<IdentityUser> _userManager;
         private readonly SignInManager<IdentityUser> _signInManager;
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
-        public ConfirmEmailChangeModel(UserManager<IdentityUser> userManager, SignInManager<IdentityUser> signInManager, IForumSessionService forumConfigService)
+        public ConfirmEmailChangeModel(UserManager<IdentityUser> userManager, SignInManager<IdentityUser> signInManager, IForumSessionService forumSessionService)
         {
             _userManager = userManager;
             _signInManager = signInManager;
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         /// <summary>
@@ -47,7 +38,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 
         public async Task<IActionResult> OnGetAsync(string userId, string email, string code)
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
 
             if (userId == null || email == null || code == null)
             {

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
@@ -31,7 +31,7 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
         private readonly IUserEmailStore<IdentityUser> _emailStore;
         private readonly IEmailSender _emailSender;
         private readonly ILogger<ExternalLoginModel> _logger;
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
         public ExternalLoginModel(
             SignInManager<IdentityUser> signInManager,
@@ -39,7 +39,7 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
             IUserStore<IdentityUser> userStore,
             ILogger<ExternalLoginModel> logger,
             IEmailSender emailSender,
-            IForumSessionService forumConfigService)
+            IForumSessionService forumSessionService)
         {
             _signInManager = signInManager;
             _userManager = userManager;
@@ -47,16 +47,7 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
             _emailStore = GetEmailStore();
             _logger = logger;
             _emailSender = emailSender;
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         /// <summary>
@@ -102,7 +93,9 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 
         public IActionResult OnGet()
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
+
             return RedirectToPage("./Login");
         } 
 
@@ -116,7 +109,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 
         public async Task<IActionResult> OnGetCallbackAsync(string returnUrl = null, string remoteError = null)
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
 
             returnUrl = returnUrl ?? Url.Content("~/");
             if (remoteError != null)

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ForgotPassword.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ForgotPassword.cshtml.cs
@@ -23,13 +23,13 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
     {
         private readonly UserManager<IdentityUser> _userManager;
         private readonly IEmailSender _emailSender;
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
-        public ForgotPasswordModel(UserManager<IdentityUser> userManager, IEmailSender emailSender, IForumSessionService forumConfigService)
+        public ForgotPasswordModel(UserManager<IdentityUser> userManager, IEmailSender emailSender, IForumSessionService forumSessionService)
         {
             _userManager = userManager;
             _emailSender = emailSender;
-            _forumConfigService = forumConfigService;
+            _forumSessionService = forumSessionService;
         }
 
         /// <summary>
@@ -54,18 +54,10 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
             public string Email { get; set; }
         }
 
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
-        }
-
         public async Task<IActionResult> OnGetAsync()
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
 
             return Page();
         }

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ForgotPasswordConfirmation.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ForgotPasswordConfirmation.cshtml.cs
@@ -17,20 +17,11 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
     [AllowAnonymous]
     public class ForgotPasswordConfirmation : PageModel
     {
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
-        public ForgotPasswordConfirmation(IForumSessionService forumConfigService)
+        public ForgotPasswordConfirmation(IForumSessionService forumSessionService)
         {
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         /// <summary>
@@ -39,7 +30,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
         /// </summary>
         public void OnGet()
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/Lockout.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/Lockout.cshtml.cs
@@ -17,20 +17,11 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
     [AllowAnonymous]
     public class LockoutModel : PageModel
     {
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
-        public LockoutModel(IForumSessionService forumConfigService)
+        public LockoutModel(IForumSessionService forumSessionService)
         {
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         /// <summary>
@@ -39,7 +30,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
         /// </summary>
         public void OnGet()
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -24,22 +24,13 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
     {
         private readonly SignInManager<IdentityUser> _signInManager;
         private readonly ILogger<LoginModel> _logger;
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
-        public LoginModel(SignInManager<IdentityUser> signInManager, ILogger<LoginModel> logger, IForumSessionService forumConfigService)
+        public LoginModel(SignInManager<IdentityUser> signInManager, ILogger<LoginModel> logger, IForumSessionService forumSessionService)
         {
             _signInManager = signInManager;
             _logger = logger;
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         /// <summary>
@@ -100,7 +91,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 
         public async Task OnGetAsync(string returnUrl = null)
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
 
             if (!string.IsNullOrEmpty(ErrorMessage))
             {

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/LoginWith2fa.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/LoginWith2fa.cshtml.cs
@@ -22,27 +22,18 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
         private readonly SignInManager<IdentityUser> _signInManager;
         private readonly UserManager<IdentityUser> _userManager;
         private readonly ILogger<LoginWith2faModel> _logger;
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
         public LoginWith2faModel(
             SignInManager<IdentityUser> signInManager,
             UserManager<IdentityUser> userManager,
             ILogger<LoginWith2faModel> logger,
-            IForumSessionService forumConfigService)
+            IForumSessionService forumSessionService)
         {
             _signInManager = signInManager;
             _userManager = userManager;
             _logger = logger;
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         /// <summary>
@@ -90,7 +81,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 
         public async Task<IActionResult> OnGetAsync(bool rememberMe, string returnUrl = null)
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
 
             // Ensure the user has gone through the username & password screen first
             var user = await _signInManager.GetTwoFactorAuthenticationUserAsync();

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/LoginWithRecoveryCode.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/LoginWithRecoveryCode.cshtml.cs
@@ -20,27 +20,18 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
         private readonly SignInManager<IdentityUser> _signInManager;
         private readonly UserManager<IdentityUser> _userManager;
         private readonly ILogger<LoginWithRecoveryCodeModel> _logger;
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
         public LoginWithRecoveryCodeModel(
             SignInManager<IdentityUser> signInManager,
             UserManager<IdentityUser> userManager,
             ILogger<LoginWithRecoveryCodeModel> logger,
-            IForumSessionService forumConfigService)
+            IForumSessionService forumSessionService)
         {
             _signInManager = signInManager;
             _userManager = userManager;
             _logger = logger;
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         /// <summary>
@@ -75,7 +66,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 
         public async Task<IActionResult> OnGetAsync(string returnUrl = null)
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
 
             // Ensure the user has gone through the username & password screen first
             var user = await _signInManager.GetTwoFactorAuthenticationUserAsync();

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/Logout.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/Logout.cshtml.cs
@@ -19,27 +19,19 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
     {
         private readonly SignInManager<IdentityUser> _signInManager;
         private readonly ILogger<LogoutModel> _logger;
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
-        public LogoutModel(SignInManager<IdentityUser> signInManager, ILogger<LogoutModel> logger, IForumSessionService forumConfigService)
+        public LogoutModel(SignInManager<IdentityUser> signInManager, ILogger<LogoutModel> logger, IForumSessionService forumSessionService)
         {
             _signInManager = signInManager;
             _logger = logger;
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         public void OnGet()
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
         }
 
         public async Task<IActionResult> OnPost(string returnUrl = null)

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -32,7 +32,7 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
         private readonly IUserEmailStore<IdentityUser> _emailStore;
         private readonly ILogger<RegisterModel> _logger;
         private readonly IEmailSender _emailSender;
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
         public RegisterModel(
             UserManager<IdentityUser> userManager,
@@ -40,7 +40,7 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
             SignInManager<IdentityUser> signInManager,
             ILogger<RegisterModel> logger,
             IEmailSender emailSender,
-            IForumSessionService forumConfigService)
+            IForumSessionService forumSessionService)
         {
             _userManager = userManager;
             _userStore = userStore;
@@ -48,16 +48,7 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
             _signInManager = signInManager;
             _logger = logger;
             _emailSender = emailSender;
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         /// <summary>
@@ -117,7 +108,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 
         public async Task OnGetAsync(string returnUrl = null)
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
 
             ReturnUrl = returnUrl;
             ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml.cs
@@ -22,22 +22,13 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
     {
         private readonly UserManager<IdentityUser> _userManager;
         private readonly IEmailSender _sender;
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
-        public RegisterConfirmationModel(UserManager<IdentityUser> userManager, IEmailSender sender, IForumSessionService forumConfigService)
+        public RegisterConfirmationModel(UserManager<IdentityUser> userManager, IEmailSender sender, IForumSessionService forumSessionService)
         {
             _userManager = userManager;
             _sender = sender;
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         /// <summary>
@@ -60,7 +51,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 
         public async Task<IActionResult> OnGetAsync(string email, string returnUrl = null)
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
 
             if (email == null)
             {

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ResendEmailConfirmation.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ResendEmailConfirmation.cshtml.cs
@@ -24,22 +24,13 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
     {
         private readonly UserManager<IdentityUser> _userManager;
         private readonly IEmailSender _emailSender;
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
-        public ResendEmailConfirmationModel(UserManager<IdentityUser> userManager, IEmailSender emailSender, IForumSessionService forumConfigService)
+        public ResendEmailConfirmationModel(UserManager<IdentityUser> userManager, IEmailSender emailSender, IForumSessionService forumSessionService)
         {
             _userManager = userManager;
             _emailSender = emailSender;
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         /// <summary>
@@ -66,7 +57,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 
         public void OnGet()
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
         }
 
         public async Task<IActionResult> OnPostAsync()

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ResetPassword.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ResetPassword.cshtml.cs
@@ -20,21 +20,12 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
     public class ResetPasswordModel : PageModel
     {
         private readonly UserManager<IdentityUser> _userManager;
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
-        public ResetPasswordModel(UserManager<IdentityUser> userManager, IForumSessionService forumConfigService)
+        public ResetPasswordModel(UserManager<IdentityUser> userManager, IForumSessionService forumSessionService)
         {
             _userManager = userManager;
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         /// <summary>
@@ -87,7 +78,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 
         public IActionResult OnGet(string code = null)
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
 
             if (code == null)
             {

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ResetPasswordConfirmation.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ResetPasswordConfirmation.cshtml.cs
@@ -17,20 +17,11 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
     [AllowAnonymous]
     public class ResetPasswordConfirmationModel : PageModel
     {
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
-        public ResetPasswordConfirmationModel(IForumSessionService forumConfigService)
+        public ResetPasswordConfirmationModel(IForumSessionService forumSessionService)
         {
-            _forumConfigService = forumConfigService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         /// <summary>
@@ -39,7 +30,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
         /// </summary>
         public void OnGet()
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Helpers/ForumSessionHelper.cs
+++ b/source/digioz.Forum/digioz.Forum/Helpers/ForumSessionHelper.cs
@@ -1,5 +1,7 @@
 ﻿using digioz.Forum.Models;
+using digioz.Forum.Services;
 using digioz.Forum.Services.Interfaces;
+using System.Security.Claims;
 
 namespace digioz.Forum.Helpers
 {
@@ -10,6 +12,14 @@ namespace digioz.Forum.Helpers
         public ForumSessionHelper(IForumSessionService forumSessionService)
         {
             _forumSessionService = forumSessionService;
+        }
+
+        public void GetSession(HttpContext httpContext, ClaimsPrincipal user)
+        {
+            var sessionId = httpContext.Session.Id;
+            var pageName = httpContext.Request.Path;
+            var sessionUserId = user.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
+            AddSession(httpContext, sessionId, pageName, sessionUserId);
         }
 
         public int GetForumUserId(string aspNetUserId)

--- a/source/digioz.Forum/digioz.Forum/Pages/Index.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Pages/Index.cshtml.cs
@@ -8,25 +8,17 @@ namespace digioz.Forum.Pages
 {
     public class IndexModel : PageModel
     {
-        private readonly IForumSessionService _forumConfigService;
+        private readonly IForumSessionService _forumSessionService;
 
         public IndexModel(IForumSessionService forumSessionService)
         {
-            _forumConfigService = forumSessionService;
-        }
-
-        private void GetSession()
-        {
-            var sessionId = HttpContext.Session.Id;
-            var pageName = Request.Path;
-            var forumSessionHelper = new ForumSessionHelper(_forumConfigService);
-            var sessionUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
-            forumSessionHelper.AddSession(HttpContext, sessionId, pageName, sessionUserId);
+            _forumSessionService = forumSessionService;
         }
 
         public void OnGet()
         {
-            GetSession();
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User);
         }
     }
 }


### PR DESCRIPTION
Renamed _forumConfigService to _forumSessionService across multiple files. Updated constructors and methods to reflect this change. Removed individual GetSession methods and centralized session handling in ForumSessionHelper. Updated ForumSessionHelper to include a new GetSession method, promoting code reuse and reducing redundancy.

ToDo - Try and figure out why SessionId changes even if the user continues browsing on the same tab.