### PR TITLE
Add ForumPermission entity and update ProductVersion

### DIFF
--- a/source/digioz.Forum/digioz.Forum/Data/Migrations/20250202233224_ForumPermissionTableAndData.Designer.cs
+++ b/source/digioz.Forum/digioz.Forum/Data/Migrations/20250202233224_ForumPermissionTableAndData.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using digioz.Forum.Data;
 
@@ -11,9 +12,11 @@ using digioz.Forum.Data;
 namespace digioz.Forum.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250202233224_ForumPermissionTableAndData")]
+    partial class ForumPermissionTableAndData
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/source/digioz.Forum/digioz.Forum/Data/Migrations/20250202233224_ForumPermissionTableAndData.cs
+++ b/source/digioz.Forum/digioz.Forum/Data/Migrations/20250202233224_ForumPermissionTableAndData.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace digioz.Forum.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class ForumPermissionTableAndData : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ForumPermission",
+                columns: table => new
+                {
+                    ForumPermissionId = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ForumId = table.Column<long>(type: "bigint", nullable: false),
+                    RoleId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    IsReadOnly = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ForumPermission", x => x.ForumPermissionId);
+                });
+
+            // Insert data for ForumId 1 and 2
+            migrationBuilder.Sql(@"
+                    DECLARE @RegisteredRoleId NVARCHAR(450) = (SELECT Id FROM AspNetRoles WHERE Name = 'Registered');
+                    DECLARE @AdministratorsRoleId NVARCHAR(450) = (SELECT Id FROM AspNetRoles WHERE Name = 'Administrators');
+                    DECLARE @ModeratorsRoleId NVARCHAR(450) = (SELECT Id FROM AspNetRoles WHERE Name = 'Moderators');
+                    DECLARE @GuestsRoleId NVARCHAR(450) = (SELECT Id FROM AspNetRoles WHERE Name = 'Guests');
+                    DECLARE @BotsRoleId NVARCHAR(450) = (SELECT Id FROM AspNetRoles WHERE Name = 'Bots');
+
+                    INSERT INTO ForumPermission (ForumId, RoleId, IsReadOnly) VALUES
+                    (1, @RegisteredRoleId, 0),
+                    (1, @AdministratorsRoleId, 0),
+                    (1, @ModeratorsRoleId, 0),
+                    (1, @GuestsRoleId, 1),
+                    (1, @BotsRoleId, 1),
+                    (2, @RegisteredRoleId, 0),
+                    (2, @AdministratorsRoleId, 0),
+                    (2, @ModeratorsRoleId, 0),
+                    (2, @GuestsRoleId, 1),
+                    (2, @BotsRoleId, 1);
+                ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ForumPermission");
+        }
+    }
+}

--- a/source/digioz.Forum/digioz.Forum/Models/DigiozForumContext.cs
+++ b/source/digioz.Forum/digioz.Forum/Models/DigiozForumContext.cs
@@ -74,6 +74,8 @@ public partial class DigiozForumContext : DbContext
 
     public virtual DbSet<ForumModule> ForumModules { get; set; }
 
+    public virtual DbSet<ForumPermission> ForumPermissions { get; set; }
+
     public virtual DbSet<ForumPollOption> ForumPollOptions { get; set; }
 
     public virtual DbSet<ForumPollVote> ForumPollVotes { get; set; }
@@ -556,6 +558,16 @@ public partial class DigiozForumContext : DbContext
                 .HasDefaultValue("");
             entity.Property(e => e.ModuleMode)
                 .HasMaxLength(255)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+        });
+
+        modelBuilder.Entity<ForumPermission>(entity =>
+        {
+            entity.HasKey(e => e.ForumPermissionId).HasName("PK__ForumPer__D3A3E3A3A3A3A3A3");
+            entity.ToTable("ForumPermission");
+            entity.Property(e => e.RoleId)
+                .HasMaxLength(450)
                 .IsUnicode(false)
                 .HasDefaultValue("");
         });

--- a/source/digioz.Forum/digioz.Forum/Models/ForumPermission.cs
+++ b/source/digioz.Forum/digioz.Forum/Models/ForumPermission.cs
@@ -1,0 +1,10 @@
+﻿namespace digioz.Forum.Models
+{
+    public partial class ForumPermission
+    {
+        public long ForumPermissionId { get; set; }
+        public long ForumId { get; set; }
+        public string RoleId { get; set; } = null!;
+        public bool IsReadOnly { get; set; }
+    }
+}


### PR DESCRIPTION
Introduced a new ForumPermission entity with corresponding model, entity configuration, and initial data seeding. Updated the ApplicationDbContextModelSnapshot to reflect the new ProductVersion "9.0.0".

- Updated ApplicationDbContextModelSnapshot.cs to change ProductVersion from "8.0.10" to "9.0.0".
- Added DbSet<ForumPermission> to DigiozForumContext.cs.
- Added entity configuration for ForumPermission in OnModelCreating.
- Created migration 20250202233224_ForumPermissionTableAndData to create ForumPermission table and insert initial data.
- Added designer file for the migration.
- Added ForumPermission model class.