### PR TITLE
Issue #40 - Add UniqueSessionId for improved session management

### DIFF
--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Acp/CustomizationManager.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Acp/CustomizationManager.cshtml.cs
@@ -1,3 +1,5 @@
+using digioz.Forum.Helpers;
+using digioz.Forum.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -7,8 +9,26 @@ namespace digioz.Forum.Areas.Forum.Pages.Acp
     [Authorize(Roles = "Administrators")]
     public class CustomizationManagerModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
+        private readonly IForumSessionService _forumSessionService;
+
+        public CustomizationManagerModel(IForumSessionService forumSessionService)
+        {
+            _forumSessionService = forumSessionService;
+        }
+
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Acp/ForumManager.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Acp/ForumManager.cshtml.cs
@@ -1,3 +1,5 @@
+using digioz.Forum.Helpers;
+using digioz.Forum.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -7,8 +9,26 @@ namespace digioz.Forum.Areas.Forum.Pages.Acp
     [Authorize(Roles = "Administrators")]
     public class ForumManagerModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
+        private readonly IForumSessionService _forumSessionService;
+
+        public ForumManagerModel(IForumSessionService forumSessionService)
+        {
+            _forumSessionService = forumSessionService;
+        }
+
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Acp/Index.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Acp/Index.cshtml.cs
@@ -1,3 +1,5 @@
+using digioz.Forum.Helpers;
+using digioz.Forum.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -7,8 +9,26 @@ namespace digioz.Forum.Areas.Forum.Pages.Acp
     [Authorize(Roles = "Administrators")]
     public class IndexModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
+        private readonly IForumSessionService _forumSessionService;
+
+        public IndexModel(IForumSessionService forumSessionService)
+        {
+            _forumSessionService = forumSessionService;
+        }
+
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Acp/MaintenanceManager.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Acp/MaintenanceManager.cshtml.cs
@@ -1,3 +1,5 @@
+using digioz.Forum.Helpers;
+using digioz.Forum.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -7,8 +9,26 @@ namespace digioz.Forum.Areas.Forum.Pages.Acp
     [Authorize(Roles = "Administrators")]
     public class MaintenanceManagerModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
+        private readonly IForumSessionService _forumSessionService;
+
+        public MaintenanceManagerModel(IForumSessionService forumSessionService)
+        {
+            _forumSessionService = forumSessionService;
+        }
+
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Acp/PermissionsManager.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Acp/PermissionsManager.cshtml.cs
@@ -1,3 +1,5 @@
+using digioz.Forum.Helpers;
+using digioz.Forum.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -7,8 +9,26 @@ namespace digioz.Forum.Areas.Forum.Pages.Acp
     [Authorize(Roles = "Administrators")]
     public class PermissionsManagerModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
+        private readonly IForumSessionService _forumSessionService;
+
+        public PermissionsManagerModel(IForumSessionService forumSessionService)
+        {
+            _forumSessionService = forumSessionService;
+        }
+
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Acp/PostManager.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Acp/PostManager.cshtml.cs
@@ -1,3 +1,5 @@
+using digioz.Forum.Helpers;
+using digioz.Forum.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -7,8 +9,26 @@ namespace digioz.Forum.Areas.Forum.Pages.Acp
     [Authorize(Roles = "Administrators")]
     public class PostManagerModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
+        private readonly IForumSessionService _forumSessionService;
+
+        public PostManagerModel(IForumSessionService forumSessionService)
+        {
+            _forumSessionService = forumSessionService;
+        }
+
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Acp/SystemSettingsManager.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Acp/SystemSettingsManager.cshtml.cs
@@ -1,3 +1,5 @@
+using digioz.Forum.Helpers;
+using digioz.Forum.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -7,8 +9,26 @@ namespace digioz.Forum.Areas.Forum.Pages.Acp
     [Authorize(Roles = "Administrators")]
     public class SystemSettingsManagerModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
+        private readonly IForumSessionService _forumSessionService;
+
+        public SystemSettingsManagerModel(IForumSessionService forumSessionService)
+        {
+            _forumSessionService = forumSessionService;
+        }
+
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Acp/UsersAndGroupsManager.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Acp/UsersAndGroupsManager.cshtml.cs
@@ -1,3 +1,5 @@
+using digioz.Forum.Helpers;
+using digioz.Forum.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -7,8 +9,26 @@ namespace digioz.Forum.Areas.Forum.Pages.Acp
     [Authorize(Roles = "Administrators")]
     public class UsersAndGroupsManagerModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
+        private readonly IForumSessionService _forumSessionService;
+
+        public UsersAndGroupsManagerModel(IForumSessionService forumSessionService)
+        {
+            _forumSessionService = forumSessionService;
+        }
+
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Faq.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Faq.cshtml.cs
@@ -8,6 +8,8 @@ namespace digioz.Forum.Areas.Forum.Pages
 {
     public class FaqModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly IForumSessionService _forumSessionService;
 
         public FaqModel(IForumSessionService forumSessionService)
@@ -17,8 +19,15 @@ namespace digioz.Forum.Areas.Forum.Pages
 
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Forum.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Forum.cshtml.cs
@@ -8,6 +8,8 @@ namespace digioz.Forum.Areas.Forum.Pages
 {
     public class ForumModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly IForumSessionService _forumSessionService;
 
         public ForumModel(IForumSessionService forumSessionService)
@@ -17,8 +19,15 @@ namespace digioz.Forum.Areas.Forum.Pages
 
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Index.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Index.cshtml.cs
@@ -13,6 +13,8 @@ namespace digioz.Forum.Areas.Forum.Pages
         [BindProperty]
         public List<digioz.Forum.Models.Forum> ForumList { get; set; }
 
+        public string UniqueSessionId { get; private set; }
+
         private readonly IForumSessionService _forumSessionService;
         private readonly ILogger<IndexModel> _logger;
         private readonly IForumService _forumService;
@@ -34,8 +36,15 @@ namespace digioz.Forum.Areas.Forum.Pages
 
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
             var userHelper = new UserHelper(_httpContextAccessor, _roleService, _userRoleService);
 
             var context = new DigiozForumContext();

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Mcp.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Mcp.cshtml.cs
@@ -8,6 +8,8 @@ namespace digioz.Forum.Areas.Forum.Pages
 {
     public class McpModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly IForumSessionService _forumSessionService;
 
         public McpModel(IForumSessionService forumSessionService)
@@ -17,8 +19,15 @@ namespace digioz.Forum.Areas.Forum.Pages
 
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Mcp/Index.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Mcp/Index.cshtml.cs
@@ -1,3 +1,5 @@
+using digioz.Forum.Helpers;
+using digioz.Forum.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -7,8 +9,26 @@ namespace digioz.Forum.Areas.Forum.Pages.Mcp
     [Authorize(Roles = "Moderator,Administrator")]
     public class IndexModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
+        private readonly IForumSessionService _forumSessionService;
+
+        public IndexModel(IForumSessionService forumSessionService)
+        {
+            _forumSessionService = forumSessionService;
+        }
+
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Members.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Members.cshtml.cs
@@ -8,6 +8,8 @@ namespace digioz.Forum.Areas.Forum.Pages
 {
     public class MembersModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly IForumSessionService _forumSessionService;
 
         public MembersModel(IForumSessionService forumSessionService)
@@ -17,8 +19,15 @@ namespace digioz.Forum.Areas.Forum.Pages
 
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Online.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Online.cshtml.cs
@@ -8,6 +8,8 @@ namespace digioz.Forum.Areas.Forum.Pages
 {
     public class OnlineModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly IForumSessionService _forumSessionService;
 
         public OnlineModel(IForumSessionService forumSessionService)
@@ -17,8 +19,15 @@ namespace digioz.Forum.Areas.Forum.Pages
 
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Privacy.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Privacy.cshtml.cs
@@ -8,19 +8,26 @@ namespace digioz.Forum.Areas.Forum.Pages
 {
     public class PrivacyModel : PageModel
     {
-        private readonly IForumSessionService _forumSessionService;
-        private readonly ILogger<PrivacyModel> _logger;
+        public string UniqueSessionId { get; private set; }
 
-        public PrivacyModel(ILogger<PrivacyModel> logger, IForumSessionService forumSessionService)
+        private readonly IForumSessionService _forumSessionService;
+
+        public PrivacyModel(IForumSessionService forumSessionService)
         {
-            _logger = logger;
             _forumSessionService = forumSessionService;
         }
 
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Profile.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Profile.cshtml.cs
@@ -8,6 +8,8 @@ namespace digioz.Forum.Areas.Forum.Pages
 {
     public class ProfileModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly IForumSessionService _forumSessionService;
 
         public ProfileModel(IForumSessionService forumSessionService)
@@ -17,8 +19,15 @@ namespace digioz.Forum.Areas.Forum.Pages
 
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Search.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Search.cshtml.cs
@@ -8,6 +8,8 @@ namespace digioz.Forum.Areas.Forum.Pages
 {
     public class SearchModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly IForumSessionService _forumSessionService;
 
         public SearchModel(IForumSessionService forumSessionService)
@@ -17,8 +19,15 @@ namespace digioz.Forum.Areas.Forum.Pages
 
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Topic.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Topic.cshtml.cs
@@ -8,6 +8,8 @@ namespace digioz.Forum.Areas.Forum.Pages
 {
     public class TopicModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly IForumSessionService _forumSessionService;
 
         public TopicModel(IForumSessionService forumSessionService)
@@ -17,8 +19,15 @@ namespace digioz.Forum.Areas.Forum.Pages
 
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Ucp.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Ucp.cshtml.cs
@@ -8,6 +8,8 @@ namespace digioz.Forum.Areas.Forum.Pages
 {
     public class UcpModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly IForumSessionService _forumSessionService;
 
         public UcpModel(IForumSessionService forumSessionService)
@@ -17,8 +19,15 @@ namespace digioz.Forum.Areas.Forum.Pages
 
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Ucp/Index.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Forum/Pages/Ucp/Index.cshtml.cs
@@ -1,3 +1,5 @@
+using digioz.Forum.Helpers;
+using digioz.Forum.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
@@ -5,8 +7,26 @@ namespace digioz.Forum.Areas.Forum.Pages.Ucp
 {
     public class IndexModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
+        private readonly IForumSessionService _forumSessionService;
+
+        public IndexModel(IForumSessionService forumSessionService)
+        {
+            _forumSessionService = forumSessionService;
+        }
+
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
+            var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/AccessDenied.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/AccessDenied.cshtml.cs
@@ -15,6 +15,7 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
     /// </summary>
     public class AccessDeniedModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
         private readonly IForumSessionService _forumSessionService;
 
         public AccessDeniedModel(IForumSessionService forumSessionService)
@@ -28,8 +29,15 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
         /// </summary>
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ConfirmEmail.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ConfirmEmail.cshtml.cs
@@ -19,6 +19,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 {
     public class ConfirmEmailModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly UserManager<IdentityUser> _userManager;
         private readonly IForumSessionService _forumSessionService;
 
@@ -36,8 +38,15 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
         public string StatusMessage { get; set; }
         public async Task<IActionResult> OnGetAsync(string userId, string code)
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
 
             if (userId == null || code == null)
             {

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ConfirmEmailChange.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ConfirmEmailChange.cshtml.cs
@@ -18,6 +18,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 {
     public class ConfirmEmailChangeModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly UserManager<IdentityUser> _userManager;
         private readonly SignInManager<IdentityUser> _signInManager;
         private readonly IForumSessionService _forumSessionService;
@@ -38,8 +40,15 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 
         public async Task<IActionResult> OnGetAsync(string userId, string email, string code)
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
 
             if (userId == null || email == null || code == null)
             {

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
@@ -25,6 +25,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
     [AllowAnonymous]
     public class ExternalLoginModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly SignInManager<IdentityUser> _signInManager;
         private readonly UserManager<IdentityUser> _userManager;
         private readonly IUserStore<IdentityUser> _userStore;
@@ -93,8 +95,15 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 
         public IActionResult OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
 
             return RedirectToPage("./Login");
         } 
@@ -109,8 +118,15 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 
         public async Task<IActionResult> OnGetCallbackAsync(string returnUrl = null, string remoteError = null)
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
 
             returnUrl = returnUrl ?? Url.Content("~/");
             if (remoteError != null)

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ForgotPassword.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ForgotPassword.cshtml.cs
@@ -21,6 +21,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 {
     public class ForgotPasswordModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly UserManager<IdentityUser> _userManager;
         private readonly IEmailSender _emailSender;
         private readonly IForumSessionService _forumSessionService;
@@ -56,8 +58,15 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 
         public async Task<IActionResult> OnGetAsync()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
 
             return Page();
         }

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ForgotPasswordConfirmation.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ForgotPasswordConfirmation.cshtml.cs
@@ -17,6 +17,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
     [AllowAnonymous]
     public class ForgotPasswordConfirmation : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly IForumSessionService _forumSessionService;
 
         public ForgotPasswordConfirmation(IForumSessionService forumSessionService)
@@ -30,8 +32,15 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
         /// </summary>
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/Lockout.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/Lockout.cshtml.cs
@@ -17,6 +17,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
     [AllowAnonymous]
     public class LockoutModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly IForumSessionService _forumSessionService;
 
         public LockoutModel(IForumSessionService forumSessionService)
@@ -30,8 +32,15 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
         /// </summary>
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -22,6 +22,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 {
     public class LoginModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly SignInManager<IdentityUser> _signInManager;
         private readonly ILogger<LoginModel> _logger;
         private readonly IForumSessionService _forumSessionService;
@@ -91,8 +93,15 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 
         public async Task OnGetAsync(string returnUrl = null)
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
 
             if (!string.IsNullOrEmpty(ErrorMessage))
             {

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/LoginWith2fa.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/LoginWith2fa.cshtml.cs
@@ -19,6 +19,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 {
     public class LoginWith2faModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly SignInManager<IdentityUser> _signInManager;
         private readonly UserManager<IdentityUser> _userManager;
         private readonly ILogger<LoginWith2faModel> _logger;
@@ -81,8 +83,15 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 
         public async Task<IActionResult> OnGetAsync(bool rememberMe, string returnUrl = null)
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
 
             // Ensure the user has gone through the username & password screen first
             var user = await _signInManager.GetTwoFactorAuthenticationUserAsync();

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/LoginWithRecoveryCode.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/LoginWithRecoveryCode.cshtml.cs
@@ -17,6 +17,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 {
     public class LoginWithRecoveryCodeModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly SignInManager<IdentityUser> _signInManager;
         private readonly UserManager<IdentityUser> _userManager;
         private readonly ILogger<LoginWithRecoveryCodeModel> _logger;
@@ -66,8 +68,15 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 
         public async Task<IActionResult> OnGetAsync(string returnUrl = null)
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
 
             // Ensure the user has gone through the username & password screen first
             var user = await _signInManager.GetTwoFactorAuthenticationUserAsync();

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/Logout.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/Logout.cshtml.cs
@@ -17,6 +17,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 {
     public class LogoutModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly SignInManager<IdentityUser> _signInManager;
         private readonly ILogger<LogoutModel> _logger;
         private readonly IForumSessionService _forumSessionService;
@@ -30,8 +32,15 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
 
         public async Task<IActionResult> OnPost(string returnUrl = null)

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -26,6 +26,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 {
     public class RegisterModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly SignInManager<IdentityUser> _signInManager;
         private readonly UserManager<IdentityUser> _userManager;
         private readonly IUserStore<IdentityUser> _userStore;
@@ -126,8 +128,15 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 
         public async Task OnGetAsync(string returnUrl = null)
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
 
             ReturnUrl = returnUrl;
             ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml.cs
@@ -20,6 +20,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
     [AllowAnonymous]
     public class RegisterConfirmationModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly UserManager<IdentityUser> _userManager;
         private readonly IEmailSender _sender;
         private readonly IForumSessionService _forumSessionService;
@@ -51,8 +53,15 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 
         public async Task<IActionResult> OnGetAsync(string email, string returnUrl = null)
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
 
             if (email == null)
             {

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ResendEmailConfirmation.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ResendEmailConfirmation.cshtml.cs
@@ -22,6 +22,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
     [AllowAnonymous]
     public class ResendEmailConfirmationModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly UserManager<IdentityUser> _userManager;
         private readonly IEmailSender _emailSender;
         private readonly IForumSessionService _forumSessionService;
@@ -57,8 +59,15 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
 
         public async Task<IActionResult> OnPostAsync()

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ResetPassword.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ResetPassword.cshtml.cs
@@ -19,6 +19,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 {
     public class ResetPasswordModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly UserManager<IdentityUser> _userManager;
         private readonly IForumSessionService _forumSessionService;
 
@@ -78,8 +80,15 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
 
         public IActionResult OnGet(string code = null)
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
 
             if (code == null)
             {

--- a/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ResetPasswordConfirmation.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Areas/Identity/Pages/Account/ResetPasswordConfirmation.cshtml.cs
@@ -17,6 +17,8 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
     [AllowAnonymous]
     public class ResetPasswordConfirmationModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly IForumSessionService _forumSessionService;
 
         public ResetPasswordConfirmationModel(IForumSessionService forumSessionService)
@@ -30,8 +32,15 @@ namespace digioz.Forum.Areas.Identity.Pages.Account
         /// </summary>
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Helpers/ForumSessionHelper.cs
+++ b/source/digioz.Forum/digioz.Forum/Helpers/ForumSessionHelper.cs
@@ -16,9 +16,9 @@ namespace digioz.Forum.Helpers
             _forumSessionService = forumSessionService;
         }
 
-        public void GetSession(HttpContext httpContext, ClaimsPrincipal user)
+        public void GetSession(HttpContext httpContext, ClaimsPrincipal user, string uniqueSessionId)
         {
-            var sessionId = httpContext.Session.Id;
+            var sessionId = uniqueSessionId;
             var pageName = httpContext.Request.Path;
             var sessionUserId = user.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
             AddSession(httpContext, sessionId, pageName, sessionUserId);

--- a/source/digioz.Forum/digioz.Forum/Pages/Index.cshtml.cs
+++ b/source/digioz.Forum/digioz.Forum/Pages/Index.cshtml.cs
@@ -8,6 +8,8 @@ namespace digioz.Forum.Pages
 {
     public class IndexModel : PageModel
     {
+        public string UniqueSessionId { get; private set; }
+
         private readonly IForumSessionService _forumSessionService;
 
         public IndexModel(IForumSessionService forumSessionService)
@@ -17,8 +19,15 @@ namespace digioz.Forum.Pages
 
         public void OnGet()
         {
+            if (string.IsNullOrEmpty(HttpContext.Session.GetString("UniqueSessionId")))
+            {
+                HttpContext.Session.SetString("UniqueSessionId", Guid.NewGuid().ToString());
+            }
+
+            UniqueSessionId = HttpContext.Session.GetString("UniqueSessionId");
+
             var forumSessionHelper = new ForumSessionHelper(_forumSessionService);
-            forumSessionHelper.GetSession(HttpContext, User);
+            forumSessionHelper.GetSession(HttpContext, User, UniqueSessionId);
         }
     }
 }

--- a/source/digioz.Forum/digioz.Forum/Services/ForumSessionService.cs
+++ b/source/digioz.Forum/digioz.Forum/Services/ForumSessionService.cs
@@ -69,8 +69,13 @@ namespace digioz.Forum.Services
         public WhoIsOnlineViewModel GetWhoIsOnline(int duration)
         {
             var model = new WhoIsOnlineViewModel();
-            model.UsersOnline = _context.ForumSessions.Where(x => x.SessionTime > System.DateTime.Now.AddMinutes(-duration)).Count();
-            model.UsersRegistered = _context.ForumSessions.Where(x => x.SessionTime > System.DateTime.Now.AddMinutes(-duration) && x.SessionUserId != 0).Count();
+            model.UsersOnline = _context.ForumSessions
+                .Where(x => x.SessionTime > System.DateTime.Now.AddMinutes(-duration))
+                .GroupBy(x => new { x.SessionIp, x.SessionId })
+                .Count();
+            model.UsersRegistered = _context.ForumSessions.Where(x => x.SessionTime > System.DateTime.Now.AddMinutes(-duration) && x.SessionUserId != 0)
+                .GroupBy(x => new { x.SessionIp, x.SessionId })
+                .Count();
             model.UsersGuests = model.UsersOnline - model.UsersRegistered;
 
             return model;


### PR DESCRIPTION
This commit introduces a `UniqueSessionId` property across multiple Razor Page models in the `digioz.Forum` project to enhance session tracking. The `ForumSessionHelper` class has been updated to accept this identifier, allowing for more precise session management.

Various page models now initialize the `UniqueSessionId` in the `OnGet` method, generating a new GUID if it doesn't exist in the session. Additionally, the `GetWhoIsOnline` method in the `ForumSessionService` class has been improved to count online and registered users more accurately by grouping sessions based on IP and session ID.

These changes collectively enhance the tracking capabilities of user sessions within the forum application.